### PR TITLE
run workflow hourly

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "42 22 * * *"
+    - cron: "42 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
If we run it hourly it's faster for any changes to be picked up (though you can also run it manually).

I kept the 42 minute mark per GitHub [suggestion of not running at the full hour](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule). Use [crontab.guru](https://crontab.guru/#42_*_*_*_*) if you, like me, never remember the crontab syntax